### PR TITLE
Add Korean Auto Correct List

### DIFF
--- a/DocumentList.xml
+++ b/DocumentList.xml
@@ -31,9 +31,11 @@
   <block-list:block block-list:abbreviated-name="나즈막하다" block-list:name="나지막하다"/>
   <block-list:block block-list:abbreviated-name="넉넉치" block-list:name="넉넉지"/>
   <block-list:block block-list:abbreviated-name="널부러지다" block-list:name="널브러지다"/>
+  <block-list:block block-list:abbreviated-name="넓다랗다" block-list:name="널따랗다"/>
   <block-list:block block-list:abbreviated-name="넓직한" block-list:name="널찍한"/>
   <block-list:block block-list:abbreviated-name="넘흐" block-list:name="너무"/>
   <block-list:block block-list:abbreviated-name="놈팽이" block-list:name="놈팡이"/>
+  <block-list:block block-list:abbreviated-name="뇌졸증" block-list:name="뇌졸중"/>
   <block-list:block block-list:abbreviated-name="누뀜뾰" block-list:name="느낌표"/>
   <block-list:block block-list:abbreviated-name="눈꼽" block-list:name="눈곱"/>
   <block-list:block block-list:abbreviated-name="느즈막이" block-list:name="느지막이"/>
@@ -174,9 +176,11 @@
   <block-list:block block-list:abbreviated-name="합격율" block-list:name="합격률"/>
   <block-list:block block-list:abbreviated-name="해도지" block-list:name="해돋이"/>
   <block-list:block block-list:abbreviated-name="해싿" block-list:name="했다"/>
+  <block-list:block block-list:abbreviated-name="핼쓱하다" block-list:name="핼쑥하다"/>
   <block-list:block block-list:abbreviated-name="햇어" block-list:name="했어"/>
   <block-list:block block-list:abbreviated-name="했써" block-list:name="했어"/>
   <block-list:block block-list:abbreviated-name="헤택" block-list:name="혜택"/>
+  <block-list:block block-list:abbreviated-name="헬쑥하다" block-list:name="핼쑥하다"/>
   <block-list:block block-list:abbreviated-name="회수" block-list:name="횟수"/>
   <block-list:block block-list:abbreviated-name="흉헙다" block-list:name="흉업다"/>
   <block-list:block block-list:abbreviated-name="힘들게싿" block-list:name="힘들겠다"/>


### PR DESCRIPTION
뇌졸증->뇌졸중
:뇌에 혈액 공급이 제대로 되지 않아 손발의 마비, 언어 장애, 호흡 곤란 등을 일으키는 증상을 나타내는 말은 ‘뇌졸중(腦卒中)’입니다.

넓다랗다->널따랗다
:‘널따랗다’는 ‘넓다’와 관련이 있지만, 소리가 [널따라타]로 굳어졌으므로 소리대로 ‘널따랗다’로 적는다.

핼쓱하다,헬쑥하다->핼쑥하다
:https://ko.dict.naver.com/#/entry/koko/9d3e82ccbba34a779ad77015ed90d948