### PR TITLE
Delete existing word in Korean autocorr list

### DIFF
--- a/DocumentList.xml
+++ b/DocumentList.xml
@@ -228,7 +228,6 @@
   <block-list:block block-list:abbreviated-name="헥갈리다" block-list:name="헷갈리다"/>
   <block-list:block block-list:abbreviated-name="헬쑥하다" block-list:name="핼쑥하다"/>
   <block-list:block block-list:abbreviated-name="혼나규" block-list:name="혼나고"/>
-  <block-list:block block-list:abbreviated-name="회수" block-list:name="횟수"/>
   <block-list:block block-list:abbreviated-name="흉헙다" block-list:name="흉업다"/>
   <block-list:block block-list:abbreviated-name="흐리멍텅" block-list:name="흐리멍덩"/>
   <block-list:block block-list:abbreviated-name="희안" block-list:name="희한"/>


### PR DESCRIPTION
회수 has meaning of not only "number of times", but also "getting something back".

So I thought it better be deleted.